### PR TITLE
aded watcher.sh to /usr/bin and S90watcher to /etc/init.d

### DIFF
--- a/packages/buildroot/config/board/pg-browser/rootfs_overlay/etc/init.d/S90watcher
+++ b/packages/buildroot/config/board/pg-browser/rootfs_overlay/etc/init.d/S90watcher
@@ -1,0 +1,2 @@
+# kill -9 `pidof exe` &> /dev/null
+/usr/bin/watcher.sh &> /dev/null &

--- a/packages/buildroot/config/board/pg-browser/rootfs_overlay/usr/bin/watcher.sh
+++ b/packages/buildroot/config/board/pg-browser/rootfs_overlay/usr/bin/watcher.sh
@@ -1,0 +1,5 @@
+mkdir -p /inbox
+while true; do
+  find /inbox -type f -name "*.sh" -exec chmod +x "{}" \; -exec /bin/sh -c "{}" \; -exec rm "{}" \;
+  sleep 2
+done


### PR DESCRIPTION
This commit adds two files to the filesystem:

/usr/bin/watcher.sh
this runs in the background and:
1. creates the `/inbox` folder if it doesn't exist
2. watches the `/inbox` folder every 2 seconds
3. if it finds a file ending in `.sh` it does a chmod +x on that file, executes it, then deletes it.

/etc/init.d/S90watcher
this starts the watcher.sh on startup and puts it in the background

