### PR TITLE
added network up and down scripts for tracking current ip address

### DIFF
--- a/packages/buildroot/config/board/pg-browser/rootfs_overlay/etc/network/if-down.d/down.sh
+++ b/packages/buildroot/config/board/pg-browser/rootfs_overlay/etc/network/if-down.d/down.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "" &> /addr.txt
+sync

--- a/packages/buildroot/config/board/pg-browser/rootfs_overlay/etc/network/if-up.d/up.sh
+++ b/packages/buildroot/config/board/pg-browser/rootfs_overlay/etc/network/if-up.d/up.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+ip route get 1 | awk '{print $7}' &> /addr.txt
+sync


### PR DESCRIPTION
These scripts write the current private ip address to a file `/addr.txt` so the client application can read it.
It took me forever to figure out that you need to add `sync` or else it takes 10-20 seconds for the new file to show up when you try to read it from the client.  argh!