### PR TITLE
Update Dockerfile to Buildroot 2022.08

### DIFF
--- a/packages/buildroot/Dockerfile
+++ b/packages/buildroot/Dockerfile
@@ -1,7 +1,7 @@
 FROM rastasheep/ubuntu-sshd:18.04
 
 # Buildroot version to use
-ARG BUILD_ROOT_RELEASE=2022.08-rc1
+ARG BUILD_ROOT_RELEASE=2022.08
 
 # Root password for SSH
 ARG ROOT_PASSWORD=browser-vm


### PR DESCRIPTION
Updating from Buildroot 2022.08-RC1 to Buildroot 2022.08 upgrades PostgreSQL from 14.4 to 14.5.